### PR TITLE
Fixing nested heading inside paragraph for markdown file

### DIFF
--- a/src/ezTxtToHtml.py
+++ b/src/ezTxtToHtml.py
@@ -50,22 +50,29 @@ def openCurrentFile(currentFile):
 def parseMarkdownToHtml(markdownLines):
     htmlContent = ""
     paragraph = False
+    heading = False
 
     for line in markdownLines:
         if line.strip() == "":
-            if paragraph:
+            if paragraph and not heading:
                 htmlContent += "</p>\n"
                 paragraph = False
         else:
-            if not paragraph:
+            if "#" in line[0]:
+                heading = True
+                line = re.sub(r'^# (.+)$', r'<h1>\1</h1>', line)
+                line = re.sub(r'^## (.+)$', r'<h2>\1</h2>', line)
+            else:
+                heading = False
+
+
+            if not paragraph and not heading:
                 htmlContent += "<p>"
                 paragraph = True
 
             line = re.sub(r'\*\*(.*?)\*\*', r'<strong>\1</strong>', line)
             line = re.sub(r'(\*|_)(.*?)\1', r'<em>\2</em>', line)
-            line = re.sub(r'^# (.+)$', r'<h1>\1</h1>', line)
-            line = re.sub(r'^## (.+)$', r'<h2>\1</h2>', line)
-
+            
             htmlContent += line.strip() + "\n"
 
     if paragraph:


### PR DESCRIPTION
add checks and condition (if line is heading) to ezTxtToHtml.py to fix nested heading inside paragraph.

#### Test Input

> markdown file

```
# H1 test

## H2 test

normal paragraph
```

#### Test Output HTML

> before fixed

```
<p><h1>H1 test</h1>
</p>
<p><h2>H2 test</h2>
</p>
<p>normal paragraph
</p>
```

> after fixed

```
<h1>H1 test</h1>
<h2>H2 test</h2>
<p>normal paragraph
</p>
```
