### PR TITLE
feat: add -c/--config argument to argparser

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,1 @@
+output = "./HTML"

--- a/src/ezTxtToHtml.py
+++ b/src/ezTxtToHtml.py
@@ -19,6 +19,8 @@ def CommandLineParser():
     parser.add_argument('-o','--output',  metavar='<output Path>',
                         help='Define output directory. Defaults to ./HTML')
     
+    parser.add_argument('-c', '--config', metavar='<config path>', help='Provide a TOML file with predefined arguments')
+    
     # Store parsed arguments received from command line
     try:
         commandLineArguments = parser.parse_args()

--- a/src/ezTxtToHtml.py
+++ b/src/ezTxtToHtml.py
@@ -4,6 +4,7 @@ import argparse
 import re
 from shutil import rmtree
 import tomllib
+import sys
 
 VERSION = '0.1'
 DEFAULTOUTPUT= './HTML'
@@ -190,7 +191,10 @@ def textToHtmlConverter(inputPath, outputPath):
 if __name__ == '__main__':
     print (f"Python Text to HTML Converter Running")
     commandLineArguments = CommandLineParser()
-    inputPath, outputPath = verifyArguments(commandLineArguments)
-    textToHtmlConverter(inputPath, outputPath)
-    
-
+    try:
+        inputPath, outputPath = verifyArguments(commandLineArguments)
+        textToHtmlConverter(inputPath, outputPath)
+    except Exception as e:
+        print(e)
+        sys.exit(1)
+    sys.exit()

--- a/src/ezTxtToHtml.py
+++ b/src/ezTxtToHtml.py
@@ -3,6 +3,7 @@ import os
 import argparse
 import re
 from shutil import rmtree
+import tomllib
 
 VERSION = '0.1'
 DEFAULTOUTPUT= './HTML'
@@ -19,7 +20,7 @@ def CommandLineParser():
     parser.add_argument('-o','--output',  metavar='<output Path>',
                         help='Define output directory. Defaults to ./HTML')
     
-    parser.add_argument('-c', '--config', metavar='<config path>', help='Provide a TOML file with predefined arguments')
+    parser.add_argument('-c', '--config', metavar='<config Path>', help='Provide a TOML file with predefined arguments')
     
     # Store parsed arguments received from command line
     try:
@@ -36,6 +37,15 @@ def deleteOutputDirectory(outputPath):
         rmtree(outputPath)
     os.makedirs(outputPath)
 
+# Load arguments from a config file
+def loadConfig(configPath):
+    try:
+        with open(configPath, "rb") as f:
+            config = tomllib.load(f)
+    except FileNotFoundError as e:
+        raise Exception(f"Config file '{configPath}' could not be found.")
+
+    return config
 
 # Validate received command line arguments
 def verifyArguments(commandLineArguments):

--- a/src/ezTxtToHtml.py
+++ b/src/ezTxtToHtml.py
@@ -49,8 +49,17 @@ def loadConfig(configPath):
 
 # Validate received command line arguments
 def verifyArguments(commandLineArguments):
+    configPath = commandLineArguments.config
     inputPath = commandLineArguments.inputPath
-    outputPath = commandLineArguments.output or f'{DEFAULTOUTPUT}'
+
+    if configPath is None:
+        outputPath = commandLineArguments.output or f'{DEFAULTOUTPUT}'
+    else:
+        config = loadConfig(configPath)
+        if "output" in config:
+            outputPath = config["output"]
+        else:
+            outputPath = f'{DEFAULTOUTPUT}'
     return inputPath, outputPath
 
 def openCurrentFile(currentFile):


### PR DESCRIPTION
- Fixes #21 
- Added -c/-config argument which will check for a config TOML file to load arguments from
- Loading from a config file will overwrite any arguments passed in normally
- Program will abend early if a provided config file path could not be loaded